### PR TITLE
fix: limit scope to current process

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -8,9 +8,19 @@ const child_process = require('child_process');
 function activate(context) {
 	const disposable = vscode.commands.registerCommand('debug-shutdown.main', function () {
 		const config = vscode.workspace.getConfiguration('debug-shutdown');
-		const signal = config.get('signal');
+		
+		let signal = config.get('signal');
+		if (signal.startsWith('SIG')) {
+			signal = signal.slice(3);
+		}
 
-		child_process.execSync(`pkill -${signal} __debug_bin`);
+		const pid = getThisDebugBinPid();
+		if (!pid) {
+			vscode.window.showErrorMessage('No __debug_bin found under the active process.');
+			return;
+		}
+
+		child_process.execSync(`kill -s ${signal} ${pid}`);
 	});
 
 	context.subscriptions.push(disposable);
@@ -21,4 +31,48 @@ function deactivate() {}
 module.exports = {
 	activate,
 	deactivate
+}
+
+function getThisDebugBinPid() {
+	const pids = getAllDebugBinPids();
+	if (pids.length === 0) {
+		return null;
+	}
+
+	for (const pid of pids) {
+		if (isAncestor(process.pid, pid)) {
+			return pid;
+		}
+	}
+
+	return null;
+}
+
+function getAllDebugBinPids() {
+	try {
+		const output = child_process.execSync(`pgrep __debug_bin`).toString();
+		return output.split('\n').filter(line => line.trim() !== '').map(line => parseInt(line.trim()));
+	} catch (error) {
+		return [];
+	}
+}
+
+function getParentPid(pid) {
+	try {
+		const output = child_process.execSync(`ps -o ppid= -p ${pid}`).toString().trim();
+		return parseInt(output);
+	} catch (error) {
+		return null;
+	}
+}
+
+function isAncestor(ancestorPid, childPid) {
+	let currentPid = childPid;
+	while (currentPid !== 1) {
+		if (currentPid === ancestorPid) {
+			return true;
+		}
+		currentPid = getParentPid(currentPid);
+	}
+	return false;
 }


### PR DESCRIPTION
Instead of sending the signal to all processes that start with `__debug_bin`, we can find the specific process we want, and send the signal only to that one process.

To do that, first we need to find all `__debug_bin` processes.  Then we can walk their parents to see if they have an ancestor that is the vscode process.

Fixes #2